### PR TITLE
Bump CMake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 # versions before 3.2 don't pass CMAKE_EXE_LINKER_FLAGS when using try_compile
 
 set(VERSION 0.8.1)

--- a/fmt/CMakeLists.txt
+++ b/fmt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Use newer policies if available, up to most recent tested version of CMake.
 if(${CMAKE_VERSION} VERSION_LESS 3.11)

--- a/rlottie/CMakeLists.txt
+++ b/rlottie/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.3 )
+cmake_minimum_required( VERSION 3.5 )
 
 #declare project
 project( rlottie VERSION 0.0.1 LANGUAGES C CXX ASM)


### PR DESCRIPTION
Closes #23. Standardizes CMake version requirements to 3.5 across the project.